### PR TITLE
CHICKEN Extension Packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *~
+*.swp
+*.import.scm
+*.so
+salmonella.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (C) John Cowan (2015). All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person 
+obtaining a copy of this software and associated documentation 
+files (the "Software"), to deal in the Software without 
+restriction, including without limitation the rights to use, copy, 
+modify, merge, publish, distribute, sublicense, and/or sell copies 
+of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be 
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ While this repository is primarily to provide a reference implementation of SRFI
 `srfi-116.release-info`
 : Describes the URL / different releases of the CHICKEN extension.
 
-Additionally, the `tests/` directory has been added to accomodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `ilists/` directory.
+Additionally, the `tests/` directory has been added to accommodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `ilists/` directory.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# SRFI 116 - Immutable Lists
+
+This repository hosts a reference implementation of SRFI 116 - Immutable List Library. The full documentation for this SRFI can be found on the [SRFI Document Reference](http://srfi.schemers.org/srfi-116/). The repository hosts a complete implementation of the SRFI, running on [CHICKEN](http://call-cc.org) Scheme.
+
+## File Description
+
+While this repository is primarily to provide a reference implementation of SRFI 116, it also currently serves as the base repository to host the library as a CHICKEN extension (egg). Thus, there are three files that are independent of the SRFI itself, and are as follows:
+
+`srfi-116.meta`
+: This file denotes metadata about the CHICKEN extension, such as author, license, and dependencies (and dependencies for tests).
+
+`srfi-116.setup`
+: This file tells the CHICKEN package manager (`chicken-install`) how to build the egg.
+
+`srfi-116.release-info`
+: Describes the URL / different releases of the CHICKEN extension.
+
+Additionally, the `tests/` directory has been added to accomodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `ilists/` directory.
+
+## License
+
+Provided under a single clause BSD license, Copyright (C) John Cowan 2015. See LICENSE for full details.
+

--- a/ilists/ilists-test.scm
+++ b/ilists/ilists-test.scm
@@ -1,5 +1,5 @@
 (use test)
-(use ilists)
+(use srfi-116)
 
 (test-group "ilists"
 
@@ -204,7 +204,7 @@
      (lambda (x) (+ x 1))
      1))
   (test squares
-    (iunfold-right zero? 
+    (iunfold-right zero?
       (lambda (x) (* x x))
       (lambda (x) (- x 1))
       10))

--- a/ilists/ilists.scm
+++ b/ilists/ilists.scm
@@ -1,4 +1,4 @@
-(module ilists ()
+(module srfi-116 ()
   (import scheme)
   (import (only chicken
     include define-record-type define-record-printer error))
@@ -28,6 +28,6 @@
   (export pair->ipair ipair->pair list->ilist ilist->list)
   (export tree->itree itree->tree gtree->itree gtree->tree)
   (export iapply)
-  (include "ilists-base.scm")
-  (include "ilists-impl.scm")
+  (include "ilists/ilists-base.scm")
+  (include "ilists/ilists-impl.scm")
 )

--- a/ilists/ilists.sld
+++ b/ilists/ilists.sld
@@ -1,4 +1,4 @@
-(define-library (ilists)
+(define-library (srfi-116)
   (import (scheme base))
   (export iq)
   (export ipair ilist xipair ipair* make-ilist ilist-tabulate iiota)

--- a/srfi-116.meta
+++ b/srfi-116.meta
@@ -1,0 +1,18 @@
+;; -*- Hen -*-
+
+((egg "srfi-116.egg")
+ ; List of files that should be bundled alongside egg
+ (files "ilists"
+        "tests"
+        "srfi-116.setup"
+        "srfi-116.meta"
+        "srfi-116.scm"
+        "LICENSE")
+
+ (license "BSD")
+ (category data)
+ (test-depends test)
+ (author "John Cowan")
+ (email "cowan@ccil.org")
+ (repo "https://github.com/scheme-requests-for-implementation/srfi-116")
+ (synopsis "Immutable Lists."))

--- a/srfi-116.release-info
+++ b/srfi-116.release-info
@@ -1,3 +1,3 @@
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-116.git")
-(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-116/tar.gz/{egg-release}")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-116/tar.gz/CHICKEN-{egg-release}")
 (release "1.0")

--- a/srfi-116.release-info
+++ b/srfi-116.release-info
@@ -1,0 +1,3 @@
+(repo git "git://github.com/scheme-requests-for-implementation/srfi-116.git")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-116/tar.gz/{egg-release}")
+(release "1.0")

--- a/srfi-116.setup
+++ b/srfi-116.setup
@@ -1,0 +1,13 @@
+;; -*- Hen -*-
+
+(define (dynld-name fn)
+  (make-pathname #f fn ##sys#load-dynamic-extension))
+
+(compile -O3 -d0 -s ilists/ilists.scm -j srfi-116 -o srfi-116.so)
+(compile -O2 -d0 -s srfi-116.import.scm)
+
+(install-extension
+ 'srfi-116
+ `(,(dynld-name "srfi-116") ,(dynld-name "srfi-116.import"))
+ `((version "1.0")))
+

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,0 +1,1 @@
+(include "../ilists/ilists-test.scm")


### PR DESCRIPTION
Implements changes necessary for packaging SRFI 116 as an extension (aka egg) for CHICKEN Scheme (http://call-cc.org).

This work was requested by John Cowan in the #chicken channel on Freenode. For the sake of clarity, I go by DeeEff on Freenode, though not here.

I would first suggest that this be merged in as a separate branch, rather than on top of master, so as to reduce the file clutter for visitors who wish to see the implementation without wanting to see the CHICKEN specific packaging files. I do not know of any way to suggest such through the PR interface, but the following can be done:

1. Create a new branch on the main repo (call it CHICKEN)
2. I'll cancel this PR
3. I'll open a new PR to the new branch instead of on master. 

Additionally, in order for this to work once it is accepted by the CHICKEN community into the list of available extensions, a tag will need to be created. It will need to be called `CHICKEN-1.0`. This can be done simply as follows (assuming you are on the CHICKEN branch where all the release files exist):

    $ git tag CHICKEN-1.0
    $ git push --tags

Afterwards, people should be able to install and use this SRFI from within CHICKEN Scheme. Contact me (Jeremy Steward) at jeremy@thatgeoguy.ca if more clarification is needed on any of the above.