### PR TITLE
Bumps version to reflect README changes.

### DIFF
--- a/srfi-116.meta
+++ b/srfi-116.meta
@@ -11,7 +11,7 @@
         "srfi-116.meta"
         "srfi-116.release-info"
         "LICENSE"
-        "README.md")
+        "README.org")
 
  (license "BSD")
  (category data)

--- a/srfi-116.release-info
+++ b/srfi-116.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.2")
 (release "1.1")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-116.git")

--- a/srfi-116.setup
+++ b/srfi-116.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-116
  `(,(dynld-name "srfi-116") ,(dynld-name "srfi-116.import"))
- `((version "1.1")))
+ `((version "1.2")))


### PR DESCRIPTION
This should correspond to a tag for `CHICKEN-1.2`.

I merely bumped the version here to reflect the new README distributed with the SRFI.