### PR TITLE
Removes hardcoded .so extension

### DIFF
--- a/srfi-116.release-info
+++ b/srfi-116.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.3")
 (release "1.2")
 (release "1.1")
 

--- a/srfi-116.setup
+++ b/srfi-116.setup
@@ -3,10 +3,10 @@
 (define (dynld-name fn)
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
-(compile -O3 -d0 -s -J ilists/ilists.scm -o srfi-116.so)
+(compile -O3 -d0 -s -J ilists/ilists.scm -o ,(dynld-name "srfi-116"))
 (compile -O2 -d0 -s srfi-116.import.scm)
 
 (install-extension
  'srfi-116
  `(,(dynld-name "srfi-116") ,(dynld-name "srfi-116.import"))
- `((version "1.2")))
+ `((version "1.3")))


### PR DESCRIPTION
Also bumps the version numbers to reflect this change.

Pointed out by Mario Goulart, this hardcoded file extension could cause issues (although on my tests with Windows, did nothing).

Could you tag a `CHICKEN-1.3` release for this? Thanks again.